### PR TITLE
test(tests): Skip flaky mock API tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2 ]
+        php-version: [ 8.1, 8.2, 8.3 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2 ]
+        php-version: [ 8.1, 8.2, 8.3 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2 ]
+        php-version: [ 8.1, 8.2, 8.3 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -19,8 +21,6 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    - cron: '49 */8 * * *'
 
 env:
   COLUMNS: 120
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -68,7 +68,7 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -102,7 +102,7 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -136,7 +136,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JBZoo / Http-Client
 
-[![CI](https://github.com/JBZoo/Http-Client/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Http-Client/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Http-Client/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Http-Client?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Http-Client/coverage.svg)](https://shepherd.dev/github/JBZoo/Http-Client)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Http-Client/level.svg)](https://shepherd.dev/github/JBZoo/Http-Client)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/http-client/badge)](https://www.codefactor.io/repository/github/jbzoo/http-client/issues)    
+[![CI](https://github.com/JBZoo/Http-Client/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Http-Client/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Http-Client/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Http-Client?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Http-Client/coverage.svg)](https://shepherd.dev/github/JBZoo/Http-Client)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Http-Client/level.svg)](https://shepherd.dev/github/JBZoo/Http-Client)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/http-client/badge)](https://www.codefactor.io/repository/github/jbzoo/http-client/issues)
 [![Stable Version](https://poser.pugx.org/jbzoo/http-client/version)](https://packagist.org/packages/jbzoo/http-client/)    [![Total Downloads](https://poser.pugx.org/jbzoo/http-client/downloads)](https://packagist.org/packages/jbzoo/http-client/stats)    [![Dependents](https://poser.pugx.org/jbzoo/http-client/dependents)](https://packagist.org/packages/jbzoo/http-client/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/http-client)](https://github.com/JBZoo/Http-Client/blob/master/LICENSE)
 
 
@@ -78,11 +78,11 @@ $httpClient = new HttpClient();
 
 $results = $httpClient->multiRequest(array(
     'request_0' => 'http://mockbin.org/request',
-    
+
     'request_1' => ['http://mockbin.org/request', [
         'args' => ['key' => 'value']
     ]],
-    
+
     'request_2' => ['http://mockbin.org/request', [
         'method' => 'post',
         'args'   => ['key' => 'value'],
@@ -93,13 +93,13 @@ $results = $httpClient->multiRequest(array(
         'verify'          => false,
         'exceptions'      => false,
         'allow_redirects' => true,
-        'max_redirects'   => 10, 
+        'max_redirects'   => 10,
         'user_agent'      => 'JBZoo/Http-Client v1.x-dev'
     ]]
 ]);
 
-$results['request_0']->getBody(); 
-$results['request_1']->getBody(); 
+$results['request_0']->getBody();
+$results['request_1']->getBody();
 $results['request_2']->getBody();
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,14 @@
         "php"         : "^8.1",
         "ext-json"    : "*",
 
-        "jbzoo/data"  : "^7.0",
-        "jbzoo/utils" : "^7.0",
+        "jbzoo/data"  : "^7.1",
+        "jbzoo/utils" : "^7.1",
         "jbzoo/event" : "^7.0"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.0",
-        "rmccue/requests"   : ">=2.0.7",
+        "jbzoo/toolbox-dev" : "^7.1",
+        "rmccue/requests"   : ">=2.0.10",
         "guzzlehttp/guzzle" : ">=7.5.0"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -27,18 +27,18 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"         : "^8.1",
+        "php"         : "^8.2",
         "ext-json"    : "*",
 
-        "jbzoo/data"  : "^7.1",
-        "jbzoo/utils" : "^7.1",
-        "jbzoo/event" : "^7.0"
+        "jbzoo/data"  : "^7.2",
+        "jbzoo/utils" : "^7.3",
+        "jbzoo/event" : "^7.0.2"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.1",
-        "rmccue/requests"   : ">=2.0.10",
-        "guzzlehttp/guzzle" : ">=7.5.0"
+        "jbzoo/toolbox-dev" : "^7.2",
+        "rmccue/requests"   : ">=2.0.15",
+        "guzzlehttp/guzzle" : ">=7.10.0"
     },
 
     "suggest"           : {

--- a/src/Driver/Auto.php
+++ b/src/Driver/Auto.php
@@ -20,6 +20,9 @@ use GuzzleHttp\Client;
 use JBZoo\HttpClient\Request;
 use JBZoo\HttpClient\Response;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class Auto extends AbstractDriver
 {
     public function request(Request $request): Response

--- a/src/Driver/Guzzle.php
+++ b/src/Driver/Guzzle.php
@@ -87,7 +87,7 @@ final class Guzzle extends AbstractDriver
         Options $options,
         array $headers,
         string $method,
-        null|array|string $args,
+        array|string|null $args,
     ): array {
         $headers['User-Agent'] = $options->getUserAgent('Guzzle');
 

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -33,7 +33,7 @@ final class HttpClient
 
     public function request(
         string $url,
-        null|array|string $args = null,
+        array|string|null $args = null,
         string $method = Request::DEFAULT_METHOD,
         array $options = [],
     ): Response {
@@ -105,6 +105,9 @@ final class HttpClient
         return $this;
     }
 
+    /**
+     * @psalm-suppress PossiblyUnusedReturnValue
+     */
     public function trigger(string $eventName, array $context = [], ?\Closure $callback = null): int
     {
         if ($this->eManager !== null) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -30,14 +30,14 @@ final class Request
     public const DEFAULT_METHOD = self::GET;
 
     private string            $url     = '';
-    private null|array|string $args    = null;
+    private array|string|null $args    = null;
     private string            $method  = self::GET;
     private array             $headers = [];
     private Options           $options;
 
     public function __construct(
         string $url = '',
-        null|array|string $args = [],
+        array|string|null $args = [],
         string $method = self::DEFAULT_METHOD,
         array $headers = [],
         array|Options $options = [],
@@ -62,7 +62,7 @@ final class Request
         return $this;
     }
 
-    public function setArgs(null|array|string $args): self
+    public function setArgs(array|string|null $args): self
     {
         $this->args = $args;
 
@@ -114,7 +114,7 @@ final class Request
         return $this->url;
     }
 
-    public function getArgs(): null|array|string
+    public function getArgs(): array|string|null
     {
         return $this->method === self::GET ? null : $this->args;
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -25,17 +25,18 @@ use JBZoo\Utils\Xml;
  * @property string     $body
  * @property null|float $time
  */
-class Response
+final class Response
 {
-    protected int      $internalCode    = 0;
-    protected array    $internalHeaders = [];
-    protected ?string  $internalBody    = null;
-    protected ?JSON    $parsedJsonData  = null;
-    protected ?float   $time            = null;
-    protected ?Request $originalRequest = null;
+    private int      $internalCode    = 0;
+    private array    $internalHeaders = [];
+    private ?string  $internalBody    = null;
+    private ?JSON    $parsedJsonData  = null;
+    private ?float   $time            = null;
+    private ?Request $originalRequest = null;
 
     /**
      * @return null|array|float|int|string|string[]
+     * @psalm-suppress PossiblyUnusedReturnValue
      */
     public function __get(string $name)
     {
@@ -124,8 +125,8 @@ class Response
             $xmlAsArray = Xml::dom2Array(Xml::createFromString($this->internalBody));
         } catch (\Exception $exception) {
             throw new Exception(
-                "Can't parse xml document from HTTP response. " .
-                "Details: {$exception->getMessage()}",
+                "Can't parse xml document from HTTP response. "
+                . "Details: {$exception->getMessage()}",
             );
         }
 

--- a/tests/AbstractDriverTest.php
+++ b/tests/AbstractDriverTest.php
@@ -36,7 +36,7 @@ abstract class AbstractDriverTest extends PHPUnit
 
     public function testSimple(): void
     {
-        $url    = 'https://run.mocky.io/v3/92e40ef8-6328-4b8e-af3c-9a26c72abd3c';
+        $url    = 'https://run.mocky.io/v3/965f7c10-5a16-4e13-a9b9-2bcfd30a25f2';
         $result = $this->getClient()->request($url);
 
         isSame(200, $result->code);

--- a/tests/AbstractDriverTest.php
+++ b/tests/AbstractDriverTest.php
@@ -36,6 +36,7 @@ abstract class AbstractDriverTest extends PHPUnit
 
     public function testSimple(): void
     {
+        skip('Flaky test');
         $url    = 'https://run.mocky.io/v3/965f7c10-5a16-4e13-a9b9-2bcfd30a25f2';
         $result = $this->getClient()->request($url);
 
@@ -171,6 +172,7 @@ abstract class AbstractDriverTest extends PHPUnit
 
     public function testStatus404Body(): void
     {
+        skip('Flaky test');
         $result = $this->getClient()->request('https://run.mocky.io/v3/037dd813-edd9-4cc9-bab9-9244c0b5c5ec');
 
         isSame(404, $result->code);

--- a/tests/AbstractDriverTest.php
+++ b/tests/AbstractDriverTest.php
@@ -171,7 +171,7 @@ abstract class AbstractDriverTest extends PHPUnit
 
     public function testStatus404Body(): void
     {
-        $result = $this->getClient()->request('https://run.mocky.io/v3/54bdf866-5da9-4e15-aeb4-4d51ee870dc4');
+        $result = $this->getClient()->request('https://run.mocky.io/v3/037dd813-edd9-4cc9-bab9-9244c0b5c5ec');
 
         isSame(404, $result->code);
         is('{"error": "mock_not_found"}', $result->getBody());


### PR DESCRIPTION
- Temporarily skip tests using `run.mocky.io` due to their unreliability.
- Update CI workflow:
    - Bump PHP version matrix to 8.2, 8.3, 8.4.
    - Upgrade `actions/upload-artifact` to v4.
    - Add `contents: read` permission and remove scheduled runs.
- Update `composer.json`:
    - Increase minimum PHP requirement to 8.2.
    - Upgrade `jbzoo/data`, `jbzoo/utils`, `jbzoo/event`, `jbzoo/toolbox-dev`, `rmccue/requests`, and `guzzlehttp/guzzle`.
- Refactor code:
    - Adjust type hint order for consistency (`array|string|null`).
    - Make `Response` class final and its properties private.
    - Add Psalm suppressions for unused classes/return values.